### PR TITLE
Fix so builds in VS2015.

### DIFF
--- a/include/jsonpack/config.hpp
+++ b/include/jsonpack/config.hpp
@@ -28,7 +28,8 @@
 #if defined __cplusplus
 #   if (__cplusplus >= 201103) & !defined(_MSC_VER)
 #       define noexcept noexcept
-#	else
+#   elif _MSC_VER>=1900
+#   else
 #		define noexcept
 #   endif
 #endif


### PR DESCRIPTION
Without this fix, you get all kinds of wierd errors in STL headers - VS2015 now supports noexcept, so defining it away really seems to confuse it.
