### PR TITLE
Type improvements

### DIFF
--- a/include/jsonpack/object.hpp
+++ b/include/jsonpack/object.hpp
@@ -123,12 +123,6 @@ enum fields
     _NULL
 };
 
-TYPE_BEGIN_NAMESPACE
-template<typename T>
-struct json_traits;
-
-JSONPACK_API_END_NAMESPACE //type
-
 /**
  * Represent a JSON value. The union wrapper can represents a:
  * - position of: integer, real, UTF-8 string, boolean or null
@@ -200,7 +194,7 @@ struct value
           ,int>::type* = nullptr ) const
     {
         T  _val;
-        type::json_traits<T&>::extract(*this, nullptr, _val);
+        json_traits<T&>::extract(*this, nullptr, _val);
         return _val;
     }
 
@@ -215,10 +209,10 @@ struct value
                     ! std::is_pointer<T>::value
                     ,int>::type* = nullptr)
     {
-        if(_field == _POS && !type::json_traits<T&>::match_token_type(*this) )
+        if(_field == _POS && !json_traits<T&>::match_token_type(*this) )
             throw type_error("Types mismatch");
 
-        type::json_traits<T&>::extract(*this, nullptr, _val);
+        json_traits<T&>::extract(*this, nullptr, _val);
     }
 
     /**

--- a/include/jsonpack/object.hpp
+++ b/include/jsonpack/object.hpp
@@ -123,6 +123,11 @@ enum fields
     _NULL
 };
 
+TYPE_BEGIN_NAMESPACE
+template<typename T, typename>
+struct json_extract_traits;
+JSONPACK_API_END_NAMESPACE //type
+
 /**
  * Represent a JSON value. The union wrapper can represents a:
  * - position of: integer, real, UTF-8 string, boolean or null
@@ -194,7 +199,7 @@ struct value
           ,int>::type* = nullptr ) const
     {
         T  _val;
-        json_traits<T&>::extract(*this, nullptr, _val);
+        type::json_extract_traits<T&>::extract(*this, nullptr, _val);
         return _val;
     }
 
@@ -212,7 +217,7 @@ struct value
         if(_field == _POS && !json_traits<T&>::match_token_type(*this) )
             throw type_error("Types mismatch");
 
-        json_traits<T&>::extract(*this, nullptr, _val);
+        type::json_extract_traits<T&>::extract(*this, nullptr, _val);
     }
 
     /**

--- a/include/jsonpack/parser.hpp
+++ b/include/jsonpack/parser.hpp
@@ -45,6 +45,11 @@ class vector;
 typedef umap<key, value, key_hash> object_t;
 typedef vector<value>  array_t;
 
+template<typename T, typename = void>
+struct json_traits;
+
+
+
 /** ****************************************************************************
  ******************************** SCANNER **************************************
  *******************************************************************************/

--- a/include/jsonpack/parser.hpp
+++ b/include/jsonpack/parser.hpp
@@ -48,6 +48,8 @@ typedef vector<value>  array_t;
 template<typename T, typename = void>
 struct json_traits;
 
+template<typename T, typename = void>
+struct json_extract_traits;
 
 
 /** ****************************************************************************

--- a/include/jsonpack/serializer/serializer_cpp03.h
+++ b/include/jsonpack/serializer/serializer_cpp03.h
@@ -525,7 +525,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
 
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 }
 
 // 2 parameters
@@ -535,7 +535,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1);
@@ -548,7 +548,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2);
@@ -561,7 +561,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3);
@@ -574,7 +574,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4);
@@ -587,7 +587,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5);
@@ -600,7 +600,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6);
@@ -613,7 +613,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7);
@@ -628,7 +628,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8);
@@ -643,7 +643,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -659,7 +659,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -675,7 +675,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -691,7 +691,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -707,7 +707,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -723,7 +723,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -739,7 +739,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -757,7 +757,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -775,7 +775,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -794,7 +794,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -813,7 +813,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -832,7 +832,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -851,7 +851,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -870,7 +870,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -889,7 +889,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -910,7 +910,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -931,7 +931,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -953,7 +953,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -975,7 +975,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -997,7 +997,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -1019,7 +1019,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -1041,7 +1041,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,
@@ -1063,7 +1063,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 {
     register std::string::size_type pos = keys.find(',');
     std::string current_key = keys.substr(0, pos);
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), v);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(),
                 v1, v2, v3, v4, v5, v6, v7, v8,

--- a/include/jsonpack/serializer/serializer_cpp11.hpp
+++ b/include/jsonpack/serializer/serializer_cpp11.hpp
@@ -54,7 +54,7 @@ static inline void make_object(const object_t &json_obj, char* json_ptr, const s
 
     std::string current_key = keys.substr(0, pos);
 
-    type::json_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), val);
+    type::json_extract_traits<T&>::extract(json_obj, json_ptr, current_key.c_str(), current_key.length(), val);
 
     make_object(json_obj, json_ptr, keys.substr(pos+1, keys.length()-1 ).c_str(), values...);
 }

--- a/include/jsonpack/type/integers.hpp
+++ b/include/jsonpack/type/integers.hpp
@@ -49,7 +49,7 @@ struct json_traits<bool, void>
 };
 
 template<>
-struct json_traits<bool&, void>
+struct json_extract_traits<bool&, void>
 {
 
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, bool &value)
@@ -122,7 +122,7 @@ struct json_traits<char, void>
 };
 
 template<>
-struct json_traits<char&, void>
+struct json_extract_traits<char&, void>
 {
 
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, char &value)
@@ -246,8 +246,8 @@ struct json_traits<T, typename std::enable_if<has_to_integral<T, int(T::*)() con
 };
 
 template<typename T >
-struct json_traits<T&, typename std::enable_if<has_to_integral<T, int(T::*)() const>::value>::type > :
-public json_traits_int_common<T, long, INT_MAX_DIGITS, json_traits<T&>>
+struct json_extract_traits<T&, typename std::enable_if<has_to_integral<T, int(T::*)() const>::value>::type > :
+public json_traits_int_common<T, long, INT_MAX_DIGITS, json_extract_traits<T&> >
 {
     static const char* type_out_of_range() { return "Int out of range"; }
     static const char* invalid_value_msg() { return "Invalid int value for key: "; }
@@ -274,8 +274,8 @@ struct json_traits<T, typename std::enable_if<std::is_enum<T>::value>::type >
 };
 
 template<typename T >
-struct json_traits<T&, typename std::enable_if<std::is_enum<T>::value>::type > :
-public json_traits_int_common<T, long, INT_MAX_DIGITS, json_traits<T&>>
+struct json_extract_traits<T&, typename std::enable_if<std::is_enum<T>::value>::type > :
+public json_traits_int_common<T, long, INT_MAX_DIGITS, json_extract_traits<T&> >
 {
     static const char* type_out_of_range() { return "Int out of range"; }
     static const char* invalid_value_msg() { return "Invalid int value for key: "; }
@@ -315,8 +315,8 @@ struct json_traits<T, typename std::enable_if<std::is_integral<T>::value>::type>
  *  int type traits specialization
  */
 template<>
-struct json_traits<int&, void> :
-public json_traits_int_common<int, long, INT_MAX_DIGITS, json_traits<int&>>
+struct json_extract_traits<int&, void> :
+public json_traits_int_common<int, long, INT_MAX_DIGITS, json_extract_traits<int&> >
 {
     static const char* type_out_of_range() { return "Int out of range"; }
     static const char* invalid_value_msg() { return "Invalid int value for key: "; }
@@ -331,8 +331,8 @@ public json_traits_int_common<int, long, INT_MAX_DIGITS, json_traits<int&>>
  *  unsigned int type traits specialization
  */
 template<>
-struct json_traits<unsigned int&, void> :
-public json_traits_int_common<unsigned int, unsigned long, UINT_MAX_DIGITS, json_traits<unsigned int&>>
+struct json_extract_traits<unsigned int&, void> :
+public json_traits_int_common<unsigned int, unsigned long, UINT_MAX_DIGITS, json_extract_traits<unsigned int&> >
 {
     static const char* type_out_of_range() { return "Unsigned int out of range"; }
     static const char* invalid_value_msg() { return "Invalid unsigned int value for key: "; }
@@ -347,8 +347,8 @@ public json_traits_int_common<unsigned int, unsigned long, UINT_MAX_DIGITS, json
  *  long type traits specialization
  */
 template<>
-struct json_traits<long&, void> :
-public json_traits_int_common<long, long, LONG_MAX_DIGITS, json_traits<long&>>
+struct json_extract_traits<long&, void> :
+public json_traits_int_common<long, long, LONG_MAX_DIGITS, json_extract_traits<long&> >
 {
     static const char* type_out_of_range() { return "Long out of range"; }
     static const char* invalid_value_msg() { return "Invalid long value for key: "; }
@@ -363,8 +363,8 @@ public json_traits_int_common<long, long, LONG_MAX_DIGITS, json_traits<long&>>
  *  unsigned long type traits specialization
  */
 template<>
-struct json_traits<unsigned long&, void> :
-public json_traits_int_common<unsigned long, unsigned long, ULONG_MAX_DIGITS, json_traits<unsigned long&>>
+struct json_extract_traits<unsigned long&, void> :
+public json_traits_int_common<unsigned long, unsigned long, ULONG_MAX_DIGITS, json_extract_traits<unsigned long&> >
 {
     static const char* type_out_of_range() { return "Unsigned long out of range"; }
     static const char* invalid_value_msg() { return "Invalid unsigned long value for key: "; }
@@ -380,19 +380,19 @@ public json_traits_int_common<unsigned long, unsigned long, ULONG_MAX_DIGITS, js
  *  unsigned long type traits specialization
  */
 template<>
-struct json_traits<long long&, void> :
-public json_traits_int_common<long long,long long, LONGLONG_MAX_DIGITS, json_traits<long long&>>
+struct json_extract_traits<long long&, void> :
+public json_traits_int_common<long long,long long, LONGLONG_MAX_DIGITS, json_extract_traits<long long&> >
 {
     static const char* type_out_of_range() { return "Long long out of range"; }
     static const char* invalid_value_msg() { return "Invalid long long value for key: "; }
-    static unsigned long str_to_int(const char* str) {
+    static long long str_to_int(const char* str) {
 #ifdef _MSC_VER
         return _strtoi64(str, nullptr, 10);
 #else
         return std::strtoll(str, nullptr, 10);
 #endif
     }
-    static unsigned long int_to_value(unsigned long l) { return l; }
+    static long long int_to_value(long long l) { return l; }
 };
 
 //**************************************************************
@@ -402,8 +402,8 @@ public json_traits_int_common<long long,long long, LONGLONG_MAX_DIGITS, json_tra
  *  unsigned long type traits specialization
  */
 template<>
-struct json_traits<unsigned long long&, void> :
-public json_traits_int_common<unsigned long long,unsigned long long, ULONGLONG_MAX_DIGITS, json_traits<unsigned long long&>>
+struct json_extract_traits<unsigned long long&, void> :
+public json_traits_int_common<unsigned long long,unsigned long long, ULONGLONG_MAX_DIGITS, json_extract_traits<unsigned long long&> >
 {
     static const char* type_out_of_range() { return "Long long out of range"; }
     static const char* invalid_value_msg() { return "Invalid long long value for key: "; }

--- a/include/jsonpack/type/json_traits_base.hpp
+++ b/include/jsonpack/type/json_traits_base.hpp
@@ -29,7 +29,7 @@ TYPE_BEGIN_NAMESPACE
  * Type traits base for json operations
  * specialization for object types
  */
-template<typename T>
+template<typename T, typename=void>
 struct json_traits
 {
     /**
@@ -51,8 +51,8 @@ struct json_traits
     }
 };
 
-template<typename T>
-struct json_traits<T&>
+template<typename T, typename U>
+struct json_traits<T&, U>
 {
     /**
      *

--- a/include/jsonpack/type/json_traits_base.hpp
+++ b/include/jsonpack/type/json_traits_base.hpp
@@ -29,7 +29,7 @@ TYPE_BEGIN_NAMESPACE
  * Type traits base for json operations
  * specialization for object types
  */
-template<typename T, typename=void>
+template<typename T, typename U=void>
 struct json_traits
 {
     /**
@@ -51,8 +51,8 @@ struct json_traits
     }
 };
 
-template<typename T, typename U>
-struct json_traits<T&, U>
+template<typename T, typename>
+struct json_extract_traits
 {
     /**
      *

--- a/include/jsonpack/type/reals.hpp
+++ b/include/jsonpack/type/reals.hpp
@@ -30,12 +30,12 @@ template<typename T>
 struct json_traits<T, typename std::enable_if<std::is_floating_point<T>::value>::type>
 {
 
-    static void append(buffer &json, const char *key, const float &value)
+    static void append(buffer &json, const char *key, const T &value)
     {
         util::json_builder::append_real(json, key, value);
     }
 
-    static void append(buffer &json, const float &value)
+    static void append(buffer &json, const T &value)
     {
         util::json_builder::append_real(json, value);
     }

--- a/include/jsonpack/type/reals.hpp
+++ b/include/jsonpack/type/reals.hpp
@@ -25,9 +25,9 @@
 JSONPACK_API_BEGIN_NAMESPACE
 TYPE_BEGIN_NAMESPACE
 
-//-------------------------- FLOAT --------------------------------
-template<>
-struct json_traits<float, void>
+//--------------------- FLOAT + DOUBLE ----------------------------
+template<typename T>
+struct json_traits<T, typename std::enable_if<std::is_floating_point<T>::value>::type>
 {
 
     static void append(buffer &json, const char *key, const float &value)
@@ -41,8 +41,9 @@ struct json_traits<float, void>
     }
 };
 
+//-------------------------- FLOAT --------------------------------
 template<>
-struct json_traits<float&, void>
+struct json_extract_traits<float&, void>
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, float &value)
     {
@@ -101,22 +102,10 @@ struct json_traits<float&, void>
 };
 
 //-------------------------- DOUBLE --------------------------------
-template<>
-struct json_traits<double, void>
-{
-    static void append(buffer &json, const char *key, const double &value)
-    {
-        util::json_builder::append_real(json, key, value);
-    }
 
-    static void append(buffer &json, const double &value)
-    {
-        util::json_builder::append_real(json, value);
-    }
-};
 
 template<>
-struct json_traits<double&, void>
+struct json_extract_traits<double&, void>
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, double &value)
     {

--- a/include/jsonpack/type/reals.hpp
+++ b/include/jsonpack/type/reals.hpp
@@ -27,7 +27,7 @@ TYPE_BEGIN_NAMESPACE
 
 //-------------------------- FLOAT --------------------------------
 template<>
-struct json_traits<float>
+struct json_traits<float, void>
 {
 
     static void append(buffer &json, const char *key, const float &value)
@@ -42,7 +42,7 @@ struct json_traits<float>
 };
 
 template<>
-struct json_traits<float&>
+struct json_traits<float&, void>
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, float &value)
     {
@@ -102,7 +102,7 @@ struct json_traits<float&>
 
 //-------------------------- DOUBLE --------------------------------
 template<>
-struct json_traits<double>
+struct json_traits<double, void>
 {
     static void append(buffer &json, const char *key, const double &value)
     {
@@ -116,7 +116,7 @@ struct json_traits<double>
 };
 
 template<>
-struct json_traits<double&>
+struct json_traits<double&, void>
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, double &value)
     {

--- a/include/jsonpack/type/sequences/sequences.hpp
+++ b/include/jsonpack/type/sequences/sequences.hpp
@@ -50,7 +50,7 @@ struct sequence_traits
 
         for(const auto &v : value)
         {
-            json_traits<type_t>::append(json, v);
+            json_traits<type_t, void>::append(json, v);
         }
 
         json.erase_last_comma();
@@ -63,7 +63,7 @@ struct sequence_traits
 
         for(const auto &v : value)
         {
-            json_traits<type_t>::append(json, v);
+            json_traits<type_t, void>::append(json, v);
         }
         json.erase_last_comma();
         json.append("],", 2);
@@ -111,9 +111,9 @@ struct sequence_traits<Seq&>
 #else
             type_t val;
 #endif  
-            if( json_traits<type_t&>::match_token_type(it) )
+            if( json_extract_traits<type_t&>::match_token_type(it) )
             {
-                json_traits<type_t&>::extract(it, json_ptr, val);
+                json_extract_traits<type_t&>::extract(it, json_ptr, val);
                 value.insert(value.end(), val); //faster way in each container
             }
             else
@@ -147,7 +147,7 @@ struct json_traits< std::array<T,N> >
 };
 
 template<typename T, std::size_t N >
-struct json_traits<std::array<T,N>& >
+struct json_extract_traits<std::array<T,N>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::array<T,N> &value)
     {
@@ -222,7 +222,7 @@ struct json_traits< std::vector<T> >
 };
 
 template<typename T>
-struct json_traits<std::vector<T>& >
+struct json_extract_traits<std::vector<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::vector<T> &value)
     {
@@ -263,7 +263,7 @@ struct json_traits< std::deque<T> >
 };
 
 template<typename T>
-struct json_traits<std::deque<T>& >
+struct json_extract_traits<std::deque<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::deque<T> &value)
     {
@@ -299,7 +299,7 @@ struct json_traits< std::list<T> >
 };
 
 template<typename T>
-struct json_traits<std::list<T>& >
+struct json_extract_traits<std::list<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::list<T> &value)
     {
@@ -336,7 +336,7 @@ struct json_traits< std::forward_list<T> >
 
 // get elements in inverse order
 template<typename T>
-struct json_traits<std::forward_list<T>& >
+struct json_extract_traits<std::forward_list<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::forward_list<T> &value)
     {
@@ -411,7 +411,7 @@ struct json_traits< std::set<T> >
 };
 
 template<typename T>
-struct json_traits<std::set<T>& >
+struct json_extract_traits<std::set<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::set<T> &value)
     {
@@ -447,7 +447,7 @@ struct json_traits< std::multiset<T> >
 };
 
 template<typename T>
-struct json_traits<std::multiset<T>& >
+struct json_extract_traits<std::multiset<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::multiset<T> &value)
     {
@@ -483,7 +483,7 @@ struct json_traits< std::unordered_set<T> >
 };
 
 template<typename T>
-struct json_traits<std::unordered_set<T>& >
+struct json_extract_traits<std::unordered_set<T>& >
 {
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::unordered_set<T> &value)
     {

--- a/include/jsonpack/type/strings.hpp
+++ b/include/jsonpack/type/strings.hpp
@@ -57,7 +57,7 @@ struct json_traits<std::string, void>
 };
 
 template<>
-struct json_traits<std::string&, void>
+struct json_extract_traits<std::string&>
 {
 
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::string &value)

--- a/include/jsonpack/type/strings.hpp
+++ b/include/jsonpack/type/strings.hpp
@@ -30,7 +30,7 @@ TYPE_BEGIN_NAMESPACE
 //-------------------------- STD::STRING -----------------------------------
 
 template<>
-struct json_traits<std::string>
+struct json_traits<std::string, void>
 {
 
     static void append(buffer &json, const char *key, const std::string &value)
@@ -57,7 +57,7 @@ struct json_traits<std::string>
 };
 
 template<>
-struct json_traits<std::string&>
+struct json_traits<std::string&, void>
 {
 
     static void extract(const object_t &json, char* json_ptr, const char *key, const std::size_t &len, std::string &value)

--- a/include/jsonpack/vector.hpp
+++ b/include/jsonpack/vector.hpp
@@ -33,11 +33,6 @@
 
 JSONPACK_API_BEGIN_NAMESPACE
 
-TYPE_BEGIN_NAMESPACE
-template<typename T>
-struct json_traits;
-JSONPACK_API_END_NAMESPACE //type
-
 /**
  * std::vector adapter overloading operator[](const char*) for easy lookup,
  * added json_unpack() member for parsing json array
@@ -150,9 +145,9 @@ public:
 #else
             type_t val;
 #endif
-            if( type::json_traits<type_t&>::match_token_type(it) )
+            if( json_traits<type_t&>::match_token_type(it) )
             {
-                type::json_traits<type_t&>::extract(it, nullptr, val);
+                json_traits<type_t&>::extract(it, nullptr, val);
                 arr.insert(arr.end(), val);
             }
             else
@@ -183,9 +178,9 @@ public:
 #else
             type_t val;
 #endif
-            if( type::json_traits<type_t&>::match_token_type(it) )
+            if( json_traits<type_t&>::match_token_type(it) )
             {
-                type::json_traits<type_t&>::extract(it, nullptr, val);
+                json_traits<type_t&>::extract(it, nullptr, val);
                 arr.push_front(val);
             }
             else
@@ -216,9 +211,9 @@ public:
 #else
             type_t val;
 #endif
-            if( type::json_traits<type_t&>::match_token_type(this->operator [](i) ) )
+            if( json_traits<type_t&>::match_token_type(this->operator [](i) ) )
             {
-                type::json_traits<type_t&>::extract(this->operator [](i), nullptr, val);
+                json_traits<type_t&>::extract(this->operator [](i), nullptr, val);
                 arr[i] = val;
             }
             else

--- a/include/jsonpack/vector.hpp
+++ b/include/jsonpack/vector.hpp
@@ -33,6 +33,11 @@
 
 JSONPACK_API_BEGIN_NAMESPACE
 
+TYPE_BEGIN_NAMESPACE
+template<typename T, typename=void>
+struct json_extract_traits;
+JSONPACK_API_END_NAMESPACE //type
+
 /**
  * std::vector adapter overloading operator[](const char*) for easy lookup,
  * added json_unpack() member for parsing json array
@@ -145,9 +150,9 @@ public:
 #else
             type_t val;
 #endif
-            if( json_traits<type_t&>::match_token_type(it) )
+            if( type::json_extract_traits<type_t&>::match_token_type(it) )
             {
-                json_traits<type_t&>::extract(it, nullptr, val);
+                type::json_extract_traits<type_t&>::extract(it, nullptr, val);
                 arr.insert(arr.end(), val);
             }
             else


### PR DESCRIPTION
As discussed under the issue, added support for reading+writing enums + BetterEnum's enums as ints (no dependency added to BetterEnum, just supporting reading as int anything with _from_integral() + _to_integral() methods) ... and then cleaned-up Integers.hpp to reduce the boilerplate code there - such a kind of cleanup there and in a few places would make the code easier to work with in further extending with more types other extensions etc.
